### PR TITLE
Feature/29 fix filters with not

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12546,6 +12546,7 @@
     "packages/objection": {
       "name": "@bitovi/objection-querystring-parser",
       "version": "0.1.2",
+      "license": "MIT",
       "dependencies": {
         "@bitovi/querystring-parser": "^0.6.2"
       },
@@ -12561,6 +12562,7 @@
     "packages/querystring-parser": {
       "name": "@bitovi/querystring-parser",
       "version": "0.6.2",
+      "license": "MIT",
       "dependencies": {
         "qs": "^6.10.3",
         "sequelize": "^6.21.2"
@@ -12578,6 +12580,7 @@
     "packages/sequelize": {
       "name": "@bitovi/sequelize-querystring-parser",
       "version": "0.1.2",
+      "license": "MIT",
       "dependencies": {
         "@bitovi/querystring-parser": "^0.6.2",
         "sequelize": "^6.21.2"

--- a/packages/objection/README.md
+++ b/packages/objection/README.md
@@ -96,6 +96,7 @@ console.log(result);
 ```
 
 ### Filter Parameters
+
 ```js
 const result = querystringParser.parse(
   "filter=or(any('age','10','20'),equals('name','mike'))"
@@ -119,6 +120,7 @@ const result = querystringParser.parse(
 > **NOTE:** The `objection-querystring-parser` does not support nested `and()` or `or()` filter expressions yet. (See the [core-parser docs](https://github.com/bitovi/querystring-parser/tree/main/packages/querystring-parser#ibm-style-operators) more details about operators.) This issue is being tracked [here](https://github.com/bitovi/querystring-parser/issues/35).
 
 > **NOTE:** The `objection-querystring-parser` does not support the `not()` filter operator yet. (See the [core-parser docs](https://github.com/bitovi/querystring-parser/tree/main/packages/querystring-parser#ibm-style-operators) more details about operators.) This issue is being tracked [here](https://github.com/bitovi/querystring-parser/issues/29).
+
 ## Example
 
 - A more practical example on how to use this library in your project can be found [here](https://github.com/bitovi/querystring-parser/tree/main/examples)

--- a/packages/objection/README.md
+++ b/packages/objection/README.md
@@ -96,7 +96,6 @@ console.log(result);
 ```
 
 ### Filter Parameters
-
 ```js
 const result = querystringParser.parse(
   "filter=or(any('age','10','20'),equals('name','mike'))"
@@ -117,6 +116,9 @@ const result = querystringParser.parse(
 };
 ```
 
+> **NOTE:** The `objection-querystring-parser` does not support nested `and()` or `or()` filter expressions yet. (See the [core-parser docs](https://github.com/bitovi/querystring-parser/tree/main/packages/querystring-parser#ibm-style-operators) more details about operators.) This issue is being tracked [here](https://github.com/bitovi/querystring-parser/issues/35).
+
+> **NOTE:** The `objection-querystring-parser` does not support the `not()` filter operator yet. (See the [core-parser docs](https://github.com/bitovi/querystring-parser/tree/main/packages/querystring-parser#ibm-style-operators) more details about operators.) This issue is being tracked [here](https://github.com/bitovi/querystring-parser/issues/29).
 ## Example
 
 - A more practical example on how to use this library in your project can be found [here](https://github.com/bitovi/querystring-parser/tree/main/examples)

--- a/packages/sequelize/lib/parse-filter.js
+++ b/packages/sequelize/lib/parse-filter.js
@@ -34,6 +34,10 @@ function parseParametersForSequelize(operator, value) {
 function sortArrayFilters(filters) {
   let parsedArray = [];
   let errors = [];
+
+  // wrap NOT sub-expressions (which are singular objects) in an array
+  filters = Array.isArray(filters) ? filters : [filters];
+
   for (let filter of filters) {
     const parsedFiltersResult = parseFilters(filter, [], false);
     parsedArray.push(parsedFiltersResult.results);
@@ -52,7 +56,8 @@ function parseFilters(filters, filtersError, isDefault = true) {
         const keys = Object.keys(filters);
         if (keys.length > 0) isValidFilters = true;
         for (let key of keys) {
-          if (key === "AND" || key === "OR") {
+          // Handle operators with sub-expressions recursively
+          if (key === "AND" || key === "OR" || key === "NOT") {
             parsedResult[SequelizeSymbols[key]] = sortArrayFilters(
               filters[key]
             );
@@ -79,12 +84,5 @@ function parseFilters(filters, filtersError, isDefault = true) {
     errors,
   };
 }
-
-console.log(
-  parseFilters(
-    { OR: [{ IN: ["#age", 10, 20] }, { "=": ["#name", "mike"] }] },
-    []
-  )
-);
 
 module.exports = parseFilters;

--- a/packages/sequelize/test/parse-filter.test.js
+++ b/packages/sequelize/test/parse-filter.test.js
@@ -125,10 +125,7 @@ describe("parseFilter", () => {
 
     {
       title: "should return valid results when using the 'NOT' operator",
-      parameters: [
-        { NOT: { "=": ["#name", "mike"] } },
-        [],
-      ],
+      parameters: [{ NOT: { "=": ["#name", "mike"] } }, []],
       expectedResults: {
         results: {
           where: {

--- a/packages/sequelize/test/parse-filter.test.js
+++ b/packages/sequelize/test/parse-filter.test.js
@@ -122,6 +122,28 @@ describe("parseFilter", () => {
         errors: [],
       },
     },
+
+    {
+      title: "should return valid results when using the 'NOT' operator",
+      parameters: [
+        { NOT: { "=": ["#name", "mike"] } },
+        [],
+      ],
+      expectedResults: {
+        results: {
+          where: {
+            [Op.not]: [
+              {
+                name: {
+                  [Op.eq]: "mike",
+                },
+              },
+            ],
+          },
+        },
+        errors: [],
+      },
+    },
   ];
 
   test.concurrent.each(testCases)(


### PR DESCRIPTION
***This is only a partial solution for this ticket***

- This PR fixes the `@bitovi/sequelize-querystring-parser` side of things.
- The `@bitovi/objection-querystring-parser` fix is blocked by #35.
- Added disclaimers about bugs to the readme.