### PR TITLE
48: update package-lock via npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -843,13 +843,8 @@
       "link": true
     },
     "node_modules/@bitovi/querystring-parser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.6.3.tgz",
-      "integrity": "sha512-seAoQdPP4gNT68kyz9GpW1c1W8dOQ4ydG364YwFcG80ZlMpGppnOQ4yQFrKz+wzHJpnJlz5BW+isBiDm2pl37A==",
-      "dependencies": {
-        "qs": "^6.10.3",
-        "sequelize": "^6.21.2"
-      }
+      "resolved": "packages/querystring-parser",
+      "link": true
     },
     "node_modules/@bitovi/sequelize-querystring-parser": {
       "resolved": "packages/sequelize",
@@ -12550,10 +12545,10 @@
     },
     "packages/objection": {
       "name": "@bitovi/objection-querystring-parser",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@bitovi/querystring-parser": "^0.6.3"
+        "@bitovi/querystring-parser": "^0.6.4"
       },
       "devDependencies": {
         "@bitovi/eslint-config": "^1.0.0",
@@ -12564,10 +12559,18 @@
         "prettier": "2.6.2"
       }
     },
+    "packages/objection/node_modules/@bitovi/querystring-parser": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.6.4.tgz",
+      "integrity": "sha512-joABgk+JSUJ+Bii16DM2LA+kw8emTsJYorAVAXXKAE6X8TJYOSIPY/OFb6FSHEtZ/bCA2yC6krN1PDNUGr5n9Q==",
+      "dependencies": {
+        "qs": "^6.10.3",
+        "sequelize": "^6.21.2"
+      }
+    },
     "packages/querystring-parser": {
       "name": "@bitovi/querystring-parser",
       "version": "0.6.3",
-      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "qs": "^6.10.3",
@@ -12585,10 +12588,10 @@
     },
     "packages/sequelize": {
       "name": "@bitovi/sequelize-querystring-parser",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@bitovi/querystring-parser": "^0.6.3",
+        "@bitovi/querystring-parser": "^0.6.4",
         "sequelize": "^6.21.2"
       },
       "devDependencies": {
@@ -12598,6 +12601,15 @@
         "eslint-config-prettier": "^8.5.0",
         "jest": "^28.1.0",
         "prettier": "2.6.2"
+      }
+    },
+    "packages/sequelize/node_modules/@bitovi/querystring-parser": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.6.4.tgz",
+      "integrity": "sha512-joABgk+JSUJ+Bii16DM2LA+kw8emTsJYorAVAXXKAE6X8TJYOSIPY/OFb6FSHEtZ/bCA2yC6krN1PDNUGr5n9Q==",
+      "dependencies": {
+        "qs": "^6.10.3",
+        "sequelize": "^6.21.2"
       }
     }
   },
@@ -13197,19 +13209,35 @@
       "version": "file:packages/objection",
       "requires": {
         "@bitovi/eslint-config": "^1.0.0",
-        "@bitovi/querystring-parser": "^0.6.3",
+        "@bitovi/querystring-parser": "^0.6.4",
         "@types/jest": "^27.5.1",
         "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^28.1.0",
         "prettier": "2.6.2"
+      },
+      "dependencies": {
+        "@bitovi/querystring-parser": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.6.4.tgz",
+          "integrity": "sha512-joABgk+JSUJ+Bii16DM2LA+kw8emTsJYorAVAXXKAE6X8TJYOSIPY/OFb6FSHEtZ/bCA2yC6krN1PDNUGr5n9Q==",
+          "requires": {
+            "qs": "^6.10.3",
+            "sequelize": "^6.21.2"
+          }
+        }
       }
     },
     "@bitovi/querystring-parser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.6.3.tgz",
-      "integrity": "sha512-seAoQdPP4gNT68kyz9GpW1c1W8dOQ4ydG364YwFcG80ZlMpGppnOQ4yQFrKz+wzHJpnJlz5BW+isBiDm2pl37A==",
+      "version": "file:packages/querystring-parser",
       "requires": {
+        "@bitovi/eslint-config": "^1.0.0",
+        "@types/jest": "^27.5.1",
+        "eslint": "^8.15.0",
+        "eslint-config-prettier": "^8.5.0",
+        "jest": "^28.1.0",
+        "lerna": "^5.1.8",
+        "prettier": "2.6.2",
         "qs": "^6.10.3",
         "sequelize": "^6.21.2"
       }
@@ -13218,13 +13246,24 @@
       "version": "file:packages/sequelize",
       "requires": {
         "@bitovi/eslint-config": "^1.0.0",
-        "@bitovi/querystring-parser": "^0.6.3",
+        "@bitovi/querystring-parser": "^0.6.4",
         "@types/jest": "^27.5.1",
         "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^28.1.0",
         "prettier": "2.6.2",
         "sequelize": "^6.21.2"
+      },
+      "dependencies": {
+        "@bitovi/querystring-parser": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.6.4.tgz",
+          "integrity": "sha512-joABgk+JSUJ+Bii16DM2LA+kw8emTsJYorAVAXXKAE6X8TJYOSIPY/OFb6FSHEtZ/bCA2yC6krN1PDNUGr5n9Q==",
+          "requires": {
+            "qs": "^6.10.3",
+            "sequelize": "^6.21.2"
+          }
+        }
       }
     },
     "@eslint/eslintrc": {


### PR DESCRIPTION
Updated the package-lock.json by cloning the repo and running `npm install`.