### PR TITLE
Export getSequelizeFindOptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   // dbaeumer.vscode-eslint extension configuration
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   // esbenp.prettier-vscode extension configuration
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -1,5 +1,6 @@
-const parse = require("./lib/parse");
+const { getSequelizeFindOptions, parse } = require("./lib/parse");
 
 module.exports = {
+  getSequelizeFindOptions,
   parse,
 };

--- a/packages/sequelize/lib/parse.js
+++ b/packages/sequelize/lib/parse.js
@@ -4,8 +4,7 @@ const parsePagination = require("./parse-page");
 const parseSort = require("./parse-sort");
 const parseInclude = require("./parse-include");
 
-function parse(query) {
-  const parsedQuery = lib.parse(query);
+function getSequelizeFindOptions(parsedQuery) {
   const {
     fields,
     filter,
@@ -45,4 +44,8 @@ function parse(query) {
   };
 }
 
-module.exports = parse;
+function parse(query) {
+  return getSequelizeFindOptions(lib.parse(query));
+}
+
+module.exports = { getSequelizeFindOptions, parse };

--- a/packages/sequelize/test/parse.test.js
+++ b/packages/sequelize/test/parse.test.js
@@ -1,5 +1,39 @@
 const { Op } = require("sequelize");
-const parse = require("../lib/parse");
+const { getSequelizeFindOptions, parse } = require("../lib/parse");
+
+describe("getSequelizeFindOptions", () => {
+  it("combines all parsers", () => {
+    expect(
+      getSequelizeFindOptions({
+        filter: { "=": ["#name", "laundry"] },
+        fields: { "": ["id", "name", "dueDate"], user: ["name"] },
+        page: { number: 3, size: 5 },
+        sort: [],
+        include: ["user"],
+        errors: { filter: [], fields: [], page: [], sort: [], include: [] },
+      }),
+    ).toEqual({
+      orm: "sequelize",
+      data: {
+        attributes: ["id", "name", "dueDate"],
+        where: {
+          name: { [Op.eq]: "laundry" },
+        },
+        include: [
+          {
+            association: "user",
+            include: [],
+            attributes: ["name"],
+          },
+        ],
+        offset: 10,
+        limit: 5,
+        subQuery: false,
+      },
+      errors: [],
+    });
+  });
+});
 
 describe("parse", () => {
   it("combines all parsers", () => {


### PR DESCRIPTION
This PR exposes existing functionality under `getSequelizeFindOptions`.

With this, we will be able make further changes for `hatchedKoa.parse.findAndCountAll` to have something like:

Input:
```
"include=user&filter[name]=laundry&fields[Todo]=id,name,dueDate&fields[User]=name&page[number]=3&page[size]=5"
```

Output:
```json
{
  "filter": { "=": ["#name", "laundry"] },
  "fields": { "Todo": ["id", "name", "dueDate"], "User": ["name"] },
  "page": { "number": 3, "size": 5 },
  "sort": [],
  "include": ["user"],
  "errors": { "filter": [], "fields": [], "page": [], "sort": [], "include": [] }
}
```

Then `hatchedKoa.recordQuery.findAndCountAll` will take our ORM-agnostic query, query Sequelize and return plain objects:

Input:
```json
{
  "filter": { "=": ["#name", "laundry"] },
  "fields": { "Todo": ["id", "name", "dueDate"], "User": ["name"] },
  "page": { "number": 3, "size": 5 },
  "sort": [],
  "include": ["user"],
  "errors": { "filter": [], "fields": [], "page": [], "sort": [], "include": [] }
}
```

Output:
```json
{
  "count": 1,
  "rows": [
    {
      "id": 1,
      "name": "laundry",
      "dueDate": "2024-01-01",
      "user": {
        "name": "John"
      }
    }
  ]
}
```

And then `hatchedKoa.serialize.findAndCountAll` will covert it to proper JSONAPI response:

Input:
```json
{
  "count": 1,
  "rows": [
    {
      "id": 1,
      "name": "laundry",
      "dueDate": "2024-01-01",
      "user": {
        "name": "John"
      }
    }
  ]
}
```

Output:
```json
{
  "jsonapi": { "version": "1.0" },
  "meta": { "unpaginatedCount": 1 },
  "data": [ ... ],
  "included": [ ... ]
}
```

Anyone who wants to keep altering the Sequelize queries will have to switch from `hatchedKoa.model.Todo` to `hatchedKoa.orm.models.Todo`.